### PR TITLE
add theme declaration for Perial

### DIFF
--- a/fiaussi/swapCssTheme.js
+++ b/fiaussi/swapCssTheme.js
@@ -13,6 +13,7 @@ function getSocietyTheme() {
     Glaz: "83308",
     Nortia: "83310",
     Default: "68007",
+    Perial: "83308"
   };
   const queryString = window.location.search;
   const urlParams = new URLSearchParams(queryString);


### PR DESCRIPTION
# Besoins 
On veut appliquer le theme de Glaz tech fi dans le formulaire lorsque la société est Perial

# Modification
Declaration du theme à utiliser dans la fonction `getSocietyTheme`. Pour le nom du compte 'Perial', le theme qui sera utilisé sera le numéro 83308 qui correspond au theme glaz tech fi